### PR TITLE
Add dev docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:12-alpine
+
+
+WORKDIR /usr/src/app
+COPY package.json .
+RUN npm install
+ADD . /usr/src/app
+RUN npm run build
+CMD [ "npm", "run", "watch" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  saltybot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./src:/usr/src/app/src


### PR DESCRIPTION
This PR adds a `Dockerfile` to the root of the project that will watch the source in the `src/` directory, recompile and restart itself when it finds changes.

you can start the image using `docker-compose up --build`

fixes #12 